### PR TITLE
Handle backspace on Android

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,8 @@ const ACTION_TYPES: ActionTypes = {
   clearOtp: 'clearOtp',
 };
 
+const BACKSPACE_KEY_CODE = 67;
+
 const reducer = (state: ReducerState, action: Actions) => {
   switch (action.type) {
     case ACTION_TYPES.setOtpTextForIndex: {
@@ -138,8 +140,9 @@ const OtpInputs = forwardRef<OtpInputsRef, Props>(
       const index = inputs.current.findIndex(input => {
         return input.current && input.current.isFocused();
       });
+      const text = event.keyCode === BACKSPACE_KEY_CODE ? '' : event.pressedKey;
 
-      handleTextChange(event.pressedKey, index);
+      handleTextChange(text, index);
     };
 
     const handleInputTextChange = ({ text, index }: { text: string; index: number }) => {


### PR DESCRIPTION
It fixes an issue with backspace on Android. It was moving to the next input instead of the previous one. Now it should work the same for both platforms.