### PR TITLE
Support expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Supported version: `react-native >= 0.59.0`
 
 ~~### Expo is currently not supported as `Clipboard` is not included in Expo SDK~~
-react native:
+bare react native:
 ```bash
 $ yarn add react-native-otp-inputs @react-native-clipboard/clipboard
 ```
@@ -70,7 +70,7 @@ import { View } from 'react-native';
 import OtpInputs from 'react-native-otp-inputs';
 
 // expo
-import {* as ExpoClipboard} from 'expo-clipboard';
+import * as ExpoClipboard from 'expo-clipboard';
 const Clipboard = {
   setString: ExpoClipboard.setStringAsync,
   getString: ExpoClipboard.getStringAsync

--- a/README.md
+++ b/README.md
@@ -15,10 +15,15 @@
 
 Supported version: `react-native >= 0.59.0`
 
-### Expo is currently not supported as `Clipboard` is not included in Expo SDK
-
+~~### Expo is currently not supported as `Clipboard` is not included in Expo SDK~~
+react native:
 ```bash
 $ yarn add react-native-otp-inputs @react-native-clipboard/clipboard
+```
+
+expo:
+```bash
+$ yarn add react-native-otp-inputs expo-clipboard
 ```
 
 ### After installation run:
@@ -64,11 +69,23 @@ import React, { Component } from 'react';
 import { View } from 'react-native';
 import OtpInputs from 'react-native-otp-inputs';
 
+// expo
+import {* as ExpoClipboard} from 'expo-clipboard';
+const Clipboard = {
+  setString: ExpoClipboard.setStringAsync,
+  getString: ExpoClipboard.getStringAsync
+}
+
+// react-native
+import Clipboard from '@react-native-clipboard/clipboard'
+
+
 export default class App extends Component {
   render() {
     return (
       <View style={styles.container}>
         <OtpInputs
+          Clipboard={Clipboard}
           handleChange={(code) => console.log(code)}
           numberOfInputs={6}
         />

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "typescript": "4.7.4"
   },
   "peerDependencies": {
-    "@react-native-clipboard/clipboard": "*",
     "react": "*",
     "react-native": "*"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import Clipboard from '@react-native-clipboard/clipboard';
 import React, {
   forwardRef,
   RefObject,
@@ -30,6 +29,11 @@ import { OtpInputsRef, SupportedKeyboardType } from './types';
 const supportAutofillFromClipboard =
   Platform.OS === 'android' || parseInt(Platform.Version as string, 10) < 14;
 
+type ClipboardType = {
+  setString(string: string): Promise<void>;
+  getString(): Promise<string>;
+}
+
 type Props = TextInputProps & {
   autofillFromClipboard: boolean;
   autofillListenerIntervalMS?: number;
@@ -43,6 +47,7 @@ type Props = TextInputProps & {
   isRTL?: boolean;
   numberOfInputs: number;
   testIDPrefix?: string;
+  Clipboard: ClipboardType;
 };
 
 const styles = StyleSheet.create({
@@ -75,6 +80,7 @@ const OtpInputs = forwardRef<OtpInputsRef, Props>(
       selectTextOnFocus = true,
       style,
       testIDPrefix = 'otpInput',
+      Clipboard,
       ...restProps
     },
     ref,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,7 +30,7 @@ const supportAutofillFromClipboard =
   Platform.OS === 'android' || parseInt(Platform.Version as string, 10) < 14;
 
 type ClipboardType = {
-  setString(string: string): Promise<void>;
+  setString(string: string): void;
   getString(): Promise<string>;
 }
 


### PR DESCRIPTION
extract Clipboard to pass as props.

Clipboard prop should satisfy

```ts
type ClipboardType = {
    setString(string: string): void;
    getString(): Promise<string>;
};
```
